### PR TITLE
Support async calls to `rdma_get_cm_event`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,16 @@ name = "rdma-cm"
 version = "0.1.0"
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["async"]
+async = ["tokio"]
 
 [dependencies]
 tracing = "0.1.26"
-nix = "0.21"
+nix = "0.23"
 arrayvec = "0.7.1"
 thiserror = "1.0.29"
+tokio = { version = "1", features = ["net"], optional = true }
 
 [build-dependencies]
 bindgen = "0.59.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,10 @@ pub enum RdmaCmError {
     RdmaEventChannel(std::io::Error),
     #[error("Unable to create RDMA Device ID.")]
     RdmaCreateId(std::io::Error),
+    #[error("Tried to set async on CM with no event channel.")]
+    SetAsync,
+    #[error("Unable to set O_NONBLOCK on event channel.")]
+    Fcntl(nix::errno::Errno),
     #[error("Unable to disconnect RDMA connction.")]
     Disconnect(std::io::Error),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,8 +33,6 @@ pub enum RdmaCmError {
     RdmaEventChannel(std::io::Error),
     #[error("Unable to create RDMA Device ID.")]
     RdmaCreateId(std::io::Error),
-    #[error("Tried to set async on CM with no event channel.")]
-    SetAsync,
     #[error("Unable to set O_NONBLOCK on event channel.")]
     Fcntl(nix::errno::Errno),
     #[error("Unable to disconnect RDMA connction.")]


### PR DESCRIPTION
Currently, calls to `rdma_get_cm_event` use the default blocking behavior (and as far as I can tell, `rdma_get_cm_event` is the only blocking call in the library). This makes them somewhat hard to call from async contexts (have to start a thread, etc).

Conveniently, `rdma_get_cm_event` gives us a fd that we can set `O_NONBLOCKING` on, and then even more conveniently instead of having to poll that fd ourselves, tokio provides a way to hook into the epoll calls it's already making, via [`AsyncFd`](https://docs.rs/tokio/1.15.0/tokio/io/unix/struct.AsyncFd.html).